### PR TITLE
Advanceable time

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ instant.set(Instant.ofEpochMilli(base + 10));
 // verify system under test to see the duration is indeed 10 millis
 ```
 
+Additionally, Clocky provides the `AdvanceableTime` utility for incrementally controlling time in your tests.
+This also guarantees that time is always incremental, since not just any `Instant` can be provided.
+
+```java
+final AdvanceableTime time = new AdvanceableTime(Instant.EPOCH); // can start at any Instant
+final Clock clock = new ManualClock(time);
+
+// create system under test, passing clock along.
+
+// invoke system under test
+time.advanceBy(Duration.ofMillis(10));
+// invoke system under test
+
+// verify system under test to see the duration is indeed 10 millis
+```
+
 ## ⚖️ License
 Clocky is licensed under the Apache License, version 2.
 See [**LICENSE**](./LICENSE) for the full text of the license.

--- a/src/main/java/it/mulders/clocky/AdvanceableTime.java
+++ b/src/main/java/it/mulders/clocky/AdvanceableTime.java
@@ -1,0 +1,58 @@
+package it.mulders.clocky;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Objects;
+
+/**
+ * Container to control time. Intended to be used in conjunction with {@link ManualClock}.
+ * This class satisfies the assumption that time is strictly increasing.
+ */
+public final class AdvanceableTime {
+    private Instant instant;
+
+    /**
+     * Creates an instance that initially returns the provided initial instant.
+     * @param initialInstant the initial point in time.
+     */
+    public AdvanceableTime(final Instant initialInstant) {
+        Objects.requireNonNull(initialInstant, "Initial instant may not be null");
+
+        this.instant = initialInstant;
+    }
+
+    /**
+     * @return the current time.
+     */
+    public Instant instant() {
+        return instant;
+    }
+
+    /**
+     * Manually advances the time by the specified duration. The duration may not be negative.
+     * @param duration amount of time to advance by.
+     */
+    public synchronized void advanceBy(final Duration duration) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("Duration may not be negative");
+        }
+
+        instant = instant.plus(duration);
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other instanceof AdvanceableTime) {
+            return this.instant.equals(((AdvanceableTime) other).instant);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return instant.hashCode();
+    }
+}

--- a/src/main/java/it/mulders/clocky/ManualClock.java
+++ b/src/main/java/it/mulders/clocky/ManualClock.java
@@ -22,17 +22,16 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * A clock that can by itself will not progress other than when it is explicitly told to do so.
- * This is a mixture between the {@link Clock#fixed(Instant, ZoneId)} and the {@link Clock#systemDefaultZone()}
- * implementations.
+ * A clock that by itself will not progress other than when it is explicitly told to do so.
+ * This clock will determine the current time by calling the function that is provided at construction.
  */
 public final class ManualClock extends Clock {
     private final Supplier<Instant> supplier;
     private final ZoneId zoneId;
 
     /**
-     * Creates an instance that always returns the instant returned by a factory method. The clock runs in the systems
-     * default time-zone.
+     * Creates an instance that always returns the instant returned by a factory method. The clock runs in the system's
+     * default time zone.
      * @param instantSupplier the function to be invoked when asked for the current time.
      */
     public ManualClock(final Supplier<Instant> instantSupplier) {
@@ -42,7 +41,7 @@ public final class ManualClock extends Clock {
     /**
      * Creates an instance that always returns the instant returned by a factory method.
      * @param instantSupplier the function to be invoked when asked for the current time.
-     * @param zoneId the time-zone to use to convert the instant to date-time.
+     * @param zoneId the time zone to use to convert the instant to date-time.
      */
     public ManualClock(final Supplier<Instant> instantSupplier, final ZoneId zoneId) {
         Objects.requireNonNull(instantSupplier, "Instant supplier may not be null");

--- a/src/main/java/it/mulders/clocky/ManualClock.java
+++ b/src/main/java/it/mulders/clocky/ManualClock.java
@@ -32,6 +32,24 @@ public final class ManualClock extends Clock {
     /**
      * Creates an instance that always returns the instant returned by a factory method. The clock runs in the system's
      * default time zone.
+     * @param advanceableTime the time to return.
+     */
+    public ManualClock(final AdvanceableTime advanceableTime) {
+        this(advanceableTime, ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates an instance that always returns the instant returned by a factory method.
+     * @param advanceableTime the time to return.
+     * @param zoneId the time zone to use to convert the instant to date-time.
+     */
+    public ManualClock(final AdvanceableTime advanceableTime, final ZoneId zoneId) {
+        this(advanceableTime::instant, zoneId);
+    }
+
+    /**
+     * Creates an instance that always returns the instant returned by a factory method. The clock runs in the system's
+     * default time zone.
      * @param instantSupplier the function to be invoked when asked for the current time.
      */
     public ManualClock(final Supplier<Instant> instantSupplier) {

--- a/src/test/java/it/mulders/clocky/AdvanceableTimeTest.java
+++ b/src/test/java/it/mulders/clocky/AdvanceableTimeTest.java
@@ -1,0 +1,54 @@
+package it.mulders.clocky;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+class AdvanceableTimeTest implements WithAssertions {
+
+    @Test
+    void instant_should_return_value_at_construction_time() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    void allows_manual_progression() throws InterruptedException {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH);
+        TestUtils.sleep(Duration.ofMillis(10));
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH);
+
+        advanceableTime.advanceBy(Duration.ofHours(2));
+
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+        TestUtils.sleep(Duration.ofMillis(10));
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+
+        advanceableTime.advanceBy(Duration.ZERO);
+
+        assertThat(advanceableTime.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+    }
+
+    @Test
+    void disallows_negative_progression() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+
+        assertThatThrownBy(() -> advanceableTime.advanceBy(Duration.ofMillis(-1))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void equals_contract() {
+        EqualsVerifier.forClass(AdvanceableTime.class)
+                .withNonnullFields("instant")
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/src/test/java/it/mulders/clocky/ManualClockTest.java
+++ b/src/test/java/it/mulders/clocky/ManualClockTest.java
@@ -39,8 +39,24 @@ class ManualClockTest implements WithAssertions {
     }
 
     @Test
+    void instant_should_return_advanceablevalue_at_construction_time() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+        final Clock clock = new ManualClock(advanceableTime);
+
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
     void millis_should_return_value_at_construction_time() {
         final Clock clock = new ManualClock(EPOCH_SUPPLIER);
+
+        assertThat(clock.millis()).isEqualTo(Instant.EPOCH.toEpochMilli());
+    }
+
+    @Test
+    void millis_should_return_advanceablevalue_at_construction_time() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+        final Clock clock = new ManualClock(advanceableTime);
 
         assertThat(clock.millis()).isEqualTo(Instant.EPOCH.toEpochMilli());
     }
@@ -53,9 +69,26 @@ class ManualClockTest implements WithAssertions {
     }
 
     @Test
+    void advanceabletime_constructor_should_use_system_default_zone() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+        final Clock clock = new ManualClock(advanceableTime);
+
+        assertThat(clock.getZone()).isEqualTo(ZoneOffset.systemDefault());
+    }
+
+    @Test
     void constructor_should_override_zone() {
         final ZoneOffset offset = ZoneOffset.ofHoursMinutes(4, 30);
         final Clock clock = new ManualClock(EPOCH_SUPPLIER, offset);
+
+        assertThat(clock.getZone()).isEqualTo(offset);
+    }
+
+    @Test
+    void advanceabletime_constructor_should_override_zone() {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+        final ZoneOffset offset = ZoneOffset.ofHoursMinutes(4, 30);
+        final Clock clock = new ManualClock(advanceableTime, offset);
 
         assertThat(clock.getZone()).isEqualTo(offset);
     }
@@ -98,6 +131,19 @@ class ManualClockTest implements WithAssertions {
         assertThat(clock.millis()).isEqualTo(updatedValue);
         TestUtils.sleep(Duration.ofMillis(10));
         assertThat(clock.millis()).isEqualTo(updatedValue);
+    }
+
+
+    @Test
+    void allows_advanceabletime_progression() throws InterruptedException {
+        final AdvanceableTime advanceableTime = new AdvanceableTime(Instant.EPOCH);
+        final Clock clock = new ManualClock(advanceableTime, ZoneOffset.UTC);
+
+        assertThat(clock.millis()).isEqualTo(0L);
+
+        advanceableTime.advanceBy(Duration.ofSeconds(10));
+
+        assertThat(clock.millis()).isEqualTo(10_000L);
     }
 
     @Test

--- a/src/test/java/it/mulders/clocky/ManualClockTest.java
+++ b/src/test/java/it/mulders/clocky/ManualClockTest.java
@@ -31,20 +31,9 @@ class ManualClockTest implements WithAssertions {
 
     private static final Supplier<Instant> EPOCH_SUPPLIER = () -> Instant.EPOCH;
 
-    @SuppressWarnings({
-            "java:S2925" // "Thread.sleep" should not be used in tests
-    })
-    private void sleep(Duration duration) throws InterruptedException {
-        Thread.sleep(duration.toMillis());
-    }
-
     @Test
-    void instant_should_return_value_at_construction_time() throws InterruptedException {
+    void instant_should_return_value_at_construction_time() {
         final Clock clock = new ManualClock(EPOCH_SUPPLIER);
-
-        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
-
-        sleep(Duration.ofMillis(10));
 
         assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
     }
@@ -101,13 +90,13 @@ class ManualClockTest implements WithAssertions {
         final Clock clock = new ManualClock(() -> Instant.ofEpochMilli(instant.get()));
 
         assertThat(clock.millis()).isEqualTo(initialValue);
-        sleep(Duration.ofMillis(10));
+        TestUtils.sleep(Duration.ofMillis(10));
         assertThat(clock.millis()).isEqualTo(initialValue);
 
         instant.set(updatedValue);
 
         assertThat(clock.millis()).isEqualTo(updatedValue);
-        sleep(Duration.ofMillis(10));
+        TestUtils.sleep(Duration.ofMillis(10));
         assertThat(clock.millis()).isEqualTo(updatedValue);
     }
 

--- a/src/test/java/it/mulders/clocky/TestUtils.java
+++ b/src/test/java/it/mulders/clocky/TestUtils.java
@@ -1,0 +1,15 @@
+package it.mulders.clocky;
+
+import java.time.Duration;
+
+class TestUtils {
+    private TestUtils() {
+    }
+
+    @SuppressWarnings({
+            "java:S2925" // "Thread.sleep" should not be used in tests
+    })
+    static void sleep(Duration duration) throws InterruptedException {
+        Thread.sleep(duration.toMillis());
+    }
+}


### PR DESCRIPTION
Implements a container for the `instantSupplier` of `ManualClock` to ensure that the known properties of time (probably need a disclaimer here) still hold (basically, that time is increasing).

This allows for a very readable API in test cases:

```java
time.advanceBy(Duation.ofSeconds(10));
```

I also took the liberty to update some of the Javadoc. I fixed a small grammatical error and replaced some documentation that, to me, was more confusing (because I started wondering why that would be the case and could not figure it out) than helpful.

This PR should be considered mutually exclusive with #198.