### PR TITLE
Advanceable clock

### DIFF
--- a/src/main/java/it/mulders/clocky/AdvanceableClock.java
+++ b/src/main/java/it/mulders/clocky/AdvanceableClock.java
@@ -1,0 +1,87 @@
+package it.mulders.clocky;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Objects;
+
+/**
+ * A clock that by itself will not progress other than when it is explicitly told to do so.
+ * This clock satisfies the assumption about clocks that time is strictly increasing.
+ */
+public final class AdvanceableClock extends Clock {
+    private Instant instant;
+    private final ZoneId zoneId;
+
+    /**
+     * Creates an instance that initially returns the provided initial instant. This clock runs in the system's default
+     * time zone.
+     * @param initialInstant the initial time of this clock.
+     */
+    public AdvanceableClock(final Instant initialInstant) {
+        this(initialInstant, ZoneId.systemDefault());
+    }
+
+    /**
+     * Creates an instance that initially returns the provided initial instant.
+     * @param initialInstant the initial time of this clock.
+     * @param zoneId the time zone to use to convert the instant to date-time.
+     */
+    public AdvanceableClock(final Instant initialInstant, final ZoneId zoneId) {
+        Objects.requireNonNull(initialInstant, "Initial instant may not be null");
+        Objects.requireNonNull(zoneId, "Zone ID may not be null");
+
+        this.instant = initialInstant;
+        this.zoneId = zoneId;
+    }
+
+    /**
+     * Manually advances the time of this clock by the specified duration. The duration may not be negative.
+     * @param duration amount of time to advance this clock by.
+     */
+    public synchronized void advanceBy(final Duration duration) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException("Duration may not be negative");
+        }
+
+        instant = instant.plus(duration);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ZoneId getZone() {
+        return zoneId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Clock withZone(ZoneId zoneId) {
+        if (Objects.equals(this.zoneId, zoneId)) {
+            return this;
+        }
+
+        return new AdvanceableClock(instant, zoneId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Instant instant() {
+        return instant;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other instanceof AdvanceableClock) {
+            final AdvanceableClock that = (AdvanceableClock) other;
+            return this.instant.equals(that.instant) && this.zoneId.equals(that.zoneId);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instant, zoneId);
+    }
+}

--- a/src/main/java/it/mulders/clocky/ManualClock.java
+++ b/src/main/java/it/mulders/clocky/ManualClock.java
@@ -22,17 +22,16 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * A clock that can by itself will not progress other than when it is explicitly told to do so.
- * This is a mixture between the {@link Clock#fixed(Instant, ZoneId)} and the {@link Clock#systemDefaultZone()}
- * implementations.
+ * A clock that by itself will not progress other than when it is explicitly told to do so.
+ * This clock will determine the current time by calling the function that is provided at construction.
  */
 public final class ManualClock extends Clock {
     private final Supplier<Instant> supplier;
     private final ZoneId zoneId;
 
     /**
-     * Creates an instance that always returns the instant returned by a factory method. The clock runs in the systems
-     * default time-zone.
+     * Creates an instance that always returns the instant returned by a factory method. The clock runs in the system's
+     * default time zone.
      * @param instantSupplier the function to be invoked when asked for the current time.
      */
     public ManualClock(final Supplier<Instant> instantSupplier) {
@@ -42,7 +41,7 @@ public final class ManualClock extends Clock {
     /**
      * Creates an instance that always returns the instant returned by a factory method.
      * @param instantSupplier the function to be invoked when asked for the current time.
-     * @param zoneId the time-zone to use to convert the instant to date-time.
+     * @param zoneId the time zone to use to convert the instant to date-time.
      */
     public ManualClock(final Supplier<Instant> instantSupplier, final ZoneId zoneId) {
         Objects.requireNonNull(instantSupplier, "Instant supplier may not be null");

--- a/src/test/java/it/mulders/clocky/AdvanceableClockTest.java
+++ b/src/test/java/it/mulders/clocky/AdvanceableClockTest.java
@@ -1,0 +1,99 @@
+package it.mulders.clocky;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+class AdvanceableClockTest implements WithAssertions {
+
+    @Test
+    void instant_should_return_value_at_construction_time() {
+        final Clock clock = new AdvanceableClock(Instant.EPOCH);
+
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    void millis_should_return_value_at_construction_time() {
+        final Clock clock = new AdvanceableClock(Instant.EPOCH);
+
+        assertThat(clock.millis()).isEqualTo(Instant.EPOCH.toEpochMilli());
+    }
+
+    @Test
+    void constructor_should_use_system_default_zone() {
+        final Clock clock = new AdvanceableClock(Instant.EPOCH);
+
+        assertThat(clock.getZone()).isEqualTo(ZoneOffset.systemDefault());
+    }
+
+    @Test
+    void constructor_should_override_zone() {
+        final ZoneOffset offset = ZoneOffset.ofHoursMinutes(4, 30);
+        final Clock clock = new AdvanceableClock(Instant.EPOCH, offset);
+
+        assertThat(clock.getZone()).isEqualTo(offset);
+    }
+
+    @Test
+    void with_same_zone_return_same_clock() {
+        final Clock clock = new AdvanceableClock(Instant.EPOCH);
+
+        final Clock newClock = clock.withZone(ZoneOffset.systemDefault());
+
+        assertThat(newClock).isSameAs(clock);
+    }
+
+    @Test
+    void with_other_zone_return_new_clock() {
+        final ZoneOffset offset = ZoneOffset.ofHoursMinutes(4, 30);
+        final Clock clock = new AdvanceableClock(Instant.EPOCH);
+
+        final Clock newClock = clock.withZone(offset);
+
+        assertThat(newClock).isNotSameAs(clock);
+        assertThat(newClock.getZone()).isEqualTo(offset);
+    }
+
+    @Test
+    void allows_manual_progression() throws InterruptedException {
+        final AdvanceableClock clock = new AdvanceableClock(Instant.EPOCH);
+
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
+        TestUtils.sleep(Duration.ofMillis(10));
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
+
+        clock.advanceBy(Duration.ofHours(2));
+
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+        TestUtils.sleep(Duration.ofMillis(10));
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+
+        clock.advanceBy(Duration.ZERO);
+
+        assertThat(clock.instant()).isEqualTo(Instant.EPOCH.plus(2, ChronoUnit.HOURS));
+    }
+
+    @Test
+    void disallows_negative_progression() {
+        final AdvanceableClock clock = new AdvanceableClock(Instant.EPOCH);
+
+        assertThatThrownBy(() -> clock.advanceBy(Duration.ofMillis(-1))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void equals_contract() {
+        EqualsVerifier.forClass(AdvanceableClock.class)
+                .withNonnullFields("instant", "zoneId")
+                .withRedefinedSuperclass()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
+    }
+}

--- a/src/test/java/it/mulders/clocky/ManualClockTest.java
+++ b/src/test/java/it/mulders/clocky/ManualClockTest.java
@@ -31,20 +31,9 @@ class ManualClockTest implements WithAssertions {
 
     private static final Supplier<Instant> EPOCH_SUPPLIER = () -> Instant.EPOCH;
 
-    @SuppressWarnings({
-            "java:S2925" // "Thread.sleep" should not be used in tests
-    })
-    private void sleep(Duration duration) throws InterruptedException {
-        Thread.sleep(duration.toMillis());
-    }
-
     @Test
-    void instant_should_return_value_at_construction_time() throws InterruptedException {
+    void instant_should_return_value_at_construction_time() {
         final Clock clock = new ManualClock(EPOCH_SUPPLIER);
-
-        assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
-
-        sleep(Duration.ofMillis(10));
 
         assertThat(clock.instant()).isEqualTo(Instant.EPOCH);
     }
@@ -101,13 +90,13 @@ class ManualClockTest implements WithAssertions {
         final Clock clock = new ManualClock(() -> Instant.ofEpochMilli(instant.get()));
 
         assertThat(clock.millis()).isEqualTo(initialValue);
-        sleep(Duration.ofMillis(10));
+        TestUtils.sleep(Duration.ofMillis(10));
         assertThat(clock.millis()).isEqualTo(initialValue);
 
         instant.set(updatedValue);
 
         assertThat(clock.millis()).isEqualTo(updatedValue);
-        sleep(Duration.ofMillis(10));
+        TestUtils.sleep(Duration.ofMillis(10));
         assertThat(clock.millis()).isEqualTo(updatedValue);
     }
 

--- a/src/test/java/it/mulders/clocky/TestUtils.java
+++ b/src/test/java/it/mulders/clocky/TestUtils.java
@@ -1,0 +1,15 @@
+package it.mulders.clocky;
+
+import java.time.Duration;
+
+class TestUtils {
+    private TestUtils() {
+    }
+
+    @SuppressWarnings({
+            "java:S2925" // "Thread.sleep" should not be used in tests
+    })
+    static void sleep(Duration duration) throws InterruptedException {
+        Thread.sleep(duration.toMillis());
+    }
+}


### PR DESCRIPTION
Implements a separate (stateful) clock that can be manually advanced. This ensures that the known properties of time (probably need a disclaimer here) still hold (basically, that time is increasing).

This allows for a very readable API in test cases:

```java
clock.advanceBy(Duation.ofSeconds(10));
```

I also took the liberty to update some of the Javadoc. I fixed a small grammatical error and replaced some documentation that, to me, was more confusing (because I started wondering why that would be the case and could not figure it out) than helpful.

This PR should be considered mutually exclusive with #197.